### PR TITLE
Upgrade ru_ru_aot dictionaries to 0.4.3

### DIFF
--- a/hunspell_ru_ru_aot/ru_ru_aot.affix
+++ b/hunspell_ru_ru_aot/ru_ru_aot.affix
@@ -5,7 +5,7 @@ FLAG num
 # to Hunspell format by Yakov Reztsov in 2011 from
 # http://sourceforge.net/projects/seman/  (http://www.aot.ru) 
 # License: LGPL v2.1.
-# Verion: 0.4.2 (updated 13.05.2018)
+# Verion: 0.4.3 (updated 27.06.2018)
 
 TRY оаеиёнстрлвпуяыюэкмдьзбгшчйжхщцфъ
 KEY йцукенгшщзхъфывапролджэячсмитьбю|её
@@ -32,13 +32,13 @@ REP 10
 REP е ё
 REP ё e
 REP тс ц
-REP ц тс	
+REP ц тс
 REP н нн
 REP нн н
-REP л лл	
-REP лл л	
+REP л лл
+REP лл л
 REP тся ться
-REP ться тся	
+REP ться тся
 
 PFX 9 Y 49
 PFX 9 0 псевдо .


### PR DESCRIPTION
Russian hunspell dictionaries version 0.4.3 from AOT.ru was released at 2018-06-27

See https://extensions.libreoffice.org/extensions/russian-spellcheck-dictionary.-based-on-works-of-aot-group/0-4.3 for details

What I've done:

 1. Downloaded `dict_ru_ru-aot-0.4.3.oxt` from extensions.libreoffice.org

 2. Extracted `russian-aot.aff` and `russian-aot.dic` from it to `hunspell_ru_ru_aot`

 3. Converted them to UTF-8:
    ```sh
    iconv -f KOI8-R -t UTF-8 -o ru_ru_aot.affix russian-aot.aff
    iconv -f KOI8-R -t UTF-8 -o ru_ru_aot.dict russian-aot.dic
    ```

 4. Tested on local PostgreSQL installation:
    ```sh
    make USE_PGXS=1 install
    make USE_PGXS=1 installcheck
    ```

 5. Committed the results